### PR TITLE
Add support for Tosca integration

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -126,13 +126,16 @@ type EVM struct {
 	Config Config
 	// global (to this context) ethereum virtual machine
 	// used throughout the execution of the tx.
-	interpreter *EVMInterpreter
+	interpreter Interpreter
 	// abort is used to abort the EVM calling operations
 	abort atomic.Bool
 	// callGasTemp holds the gas available for the current call. This is needed because the
 	// available gas is calculated in gasCall* according to the 63/64 rule and later
 	// applied in opCall*.
 	callGasTemp uint64
+
+	// An optional override to intercept EVM calls.
+	CallInterceptor CallContextInterceptor
 }
 
 // NewEVM returns a new EVM. The returned EVM is not thread safe and should
@@ -157,7 +160,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil, blockCtx.Time),
 	}
-	evm.interpreter = NewEVMInterpreter(evm)
+	evm.interpreter = NewInterpreter(config.InterpreterImpl, evm, config)
 	return evm
 }
 
@@ -180,7 +183,7 @@ func (evm *EVM) Cancelled() bool {
 }
 
 // Interpreter returns the current interpreter
-func (evm *EVM) Interpreter() *EVMInterpreter {
+func (evm *EVM) Interpreter() Interpreter {
 	return evm.interpreter
 }
 
@@ -189,6 +192,9 @@ func (evm *EVM) Interpreter() *EVMInterpreter {
 // the necessary steps to create accounts and reverses the state in case of an
 // execution error or failed value transfer.
 func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallInterceptor != nil {
+		return evm.CallInterceptor.Call(evm, caller, addr, input, gas, value)
+	}
 	// Capture the tracer start/end events in debug mode
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, CALL, caller.Address(), addr, input, gas, value.ToBig())
@@ -264,6 +270,9 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 // CallCode differs from Call in the sense that it executes the given address'
 // code with the caller as context.
 func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, gas uint64, value *uint256.Int) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallInterceptor != nil {
+		return evm.CallInterceptor.CallCode(evm, caller, addr, input, gas, value)
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, CALLCODE, caller.Address(), addr, input, gas, value.ToBig())
@@ -315,6 +324,9 @@ func (evm *EVM) CallCode(caller ContractRef, addr common.Address, input []byte, 
 // DelegateCall differs from CallCode in the sense that it executes the given address'
 // code with the caller as context and the caller is set to the caller of the caller.
 func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallInterceptor != nil {
+		return evm.CallInterceptor.DelegateCall(evm, caller, addr, input, gas)
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		// NOTE: caller must, at all times be a contract. It should never happen
@@ -360,6 +372,9 @@ func (evm *EVM) DelegateCall(caller ContractRef, addr common.Address, input []by
 // Opcodes that attempt to perform such modifications will result in exceptions
 // instead of performing the modifications.
 func (evm *EVM) StaticCall(caller ContractRef, addr common.Address, input []byte, gas uint64) (ret []byte, leftOverGas uint64, err error) {
+	if evm.CallInterceptor != nil {
+		return evm.CallInterceptor.StaticCall(evm, caller, addr, input, gas)
+	}
 	// Invoke tracer hooks that signal entering/exiting a call frame
 	if evm.Config.Tracer != nil {
 		evm.captureBegin(evm.depth, STATICCALL, caller.Address(), addr, input, gas, nil)
@@ -531,6 +546,9 @@ func (evm *EVM) create(caller ContractRef, codeAndHash *codeAndHash, gas uint64,
 
 // Create creates a new contract using code as deployment code.
 func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
+	if evm.CallInterceptor != nil {
+		return evm.CallInterceptor.Create(evm, caller, code, gas, value)
+	}
 	contractAddr = crypto.CreateAddress(caller.Address(), evm.StateDB.GetNonce(caller.Address()))
 	return evm.create(caller, &codeAndHash{code: code}, gas, value, contractAddr, CREATE)
 }
@@ -540,6 +558,9 @@ func (evm *EVM) Create(caller ContractRef, code []byte, gas uint64, value *uint2
 // The different between Create2 with Create is Create2 uses keccak256(0xff ++ msg.sender ++ salt ++ keccak256(init_code))[12:]
 // instead of the usual sender-and-nonce-hash as the address where the contract is initialized at.
 func (evm *EVM) Create2(caller ContractRef, code []byte, gas uint64, endowment *uint256.Int, salt *uint256.Int) (ret []byte, contractAddr common.Address, leftOverGas uint64, err error) {
+	if evm.CallInterceptor != nil {
+		return evm.CallInterceptor.Create2(evm, caller, code, gas, endowment, salt)
+	}
 	codeAndHash := &codeAndHash{code: code}
 	contractAddr = crypto.CreateAddress2(caller.Address(), salt.Bytes32(), codeAndHash.Hash().Bytes())
 	return evm.create(caller, codeAndHash, gas, endowment, contractAddr, CREATE2)

--- a/core/vm/instructions_test.go
+++ b/core/vm/instructions_test.go
@@ -117,7 +117,7 @@ func testTwoOperandOp(t *testing.T, tests []TwoOperandTestcase, opFn executionFu
 		expected := new(uint256.Int).SetBytes(common.Hex2Bytes(test.Expected))
 		stack.push(x)
 		stack.push(y)
-		opFn(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opFn(&pc, evmInterpreter.(*EVMInterpreter), &ScopeContext{nil, stack, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", name, len(stack.data))
 		}
@@ -259,7 +259,7 @@ func TestWriteExpectedValues(t *testing.T) {
 			y := new(uint256.Int).SetBytes(common.Hex2Bytes(param.y))
 			stack.push(x)
 			stack.push(y)
-			opFn(&pc, interpreter, &ScopeContext{nil, stack, nil})
+			opFn(&pc, interpreter.(*EVMInterpreter), &ScopeContext{nil, stack, nil})
 			actual := stack.pop()
 			result[i] = TwoOperandTestcase{param.x, param.y, fmt.Sprintf("%064x", actual)}
 		}
@@ -734,7 +734,7 @@ func TestRandom(t *testing.T) {
 			pc             = uint64(0)
 			evmInterpreter = env.interpreter
 		)
-		opRandom(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opRandom(&pc, evmInterpreter.(*EVMInterpreter), &ScopeContext{nil, stack, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
 		}
@@ -776,7 +776,7 @@ func TestBlobHash(t *testing.T) {
 			evmInterpreter = env.interpreter
 		)
 		stack.push(uint256.NewInt(tt.idx))
-		opBlobHash(&pc, evmInterpreter, &ScopeContext{nil, stack, nil})
+		opBlobHash(&pc, evmInterpreter.(*EVMInterpreter), &ScopeContext{nil, stack, nil})
 		if len(stack.data) != 1 {
 			t.Errorf("Expected one item on stack after %v, got %d: ", tt.name, len(stack.data))
 		}
@@ -917,7 +917,7 @@ func TestOpMCopy(t *testing.T) {
 			mem.Resize(memorySize)
 		}
 		// Do the copy
-		opMcopy(&pc, evmInterpreter, &ScopeContext{mem, stack, nil})
+		opMcopy(&pc, evmInterpreter.(*EVMInterpreter), &ScopeContext{mem, stack, nil})
 		want := common.FromHex(strings.ReplaceAll(tc.want, " ", ""))
 		if have := mem.store; !bytes.Equal(want, have) {
 			t.Errorf("case %d: \nwant: %#x\nhave: %#x\n", i, want, have)

--- a/core/vm/tosca_integration.go
+++ b/core/vm/tosca_integration.go
@@ -1,0 +1,134 @@
+package vm
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/holiman/uint256"
+)
+
+// Gas table
+func MemoryGasCost(mem *Memory, wordSize uint64) (uint64, error) {
+	return memoryGasCost(mem, wordSize)
+}
+
+// Stack
+func NewStack() *Stack {
+	return newstack()
+}
+
+func (st *Stack) Len() int {
+	return st.len()
+}
+
+func (st *Stack) Push(d *uint256.Int) {
+	st.push(d)
+}
+
+// EVM
+func (evm *EVM) GetDepth() int {
+	return evm.depth
+}
+
+func (evm *EVM) SetDepth(depth int) {
+	evm.depth = depth
+}
+
+// CallContext Call interceptor
+// CallContextInterceptor provides a basic interface for the EVM calling conventions. The EVM
+// depends on this context being implemented for doing subcalls and initialising new EVM contracts.
+// Based on ethereum's CallContext Interface
+type CallContextInterceptor interface {
+	// Call calls another contract.
+	Call(env *EVM, me ContractRef, addr common.Address, data []byte, gas uint64, value *uint256.Int) ([]byte, uint64, error)
+	// CallCode takes another contracts code and execute within our own context
+	CallCode(env *EVM, me ContractRef, addr common.Address, data []byte, gas uint64, value *uint256.Int) ([]byte, uint64, error)
+	// DelegateCall is same as CallCode except sender and value is propagated from parent to child scope
+	DelegateCall(env *EVM, me ContractRef, addr common.Address, data []byte, gas uint64) ([]byte, uint64, error)
+	// Create creates a new contract
+	Create(env *EVM, me ContractRef, data []byte, gas uint64, value *uint256.Int) ([]byte, common.Address, uint64, error)
+	// Create2 creates a new contract with a deterministic address
+	Create2(env *EVM, me ContractRef, code []byte, gas uint64, value *uint256.Int, salt *uint256.Int) ([]byte, common.Address, uint64, error)
+	// StaticCall executes a contract in read-only mode
+	StaticCall(env *EVM, me ContractRef, addr common.Address, input []byte, gas uint64) ([]byte, uint64, error)
+}
+
+// -- Interpreter Implementation Registry --
+
+// Interpreter defines an interface for different interpreter implementations.
+type Interpreter interface {
+	// Run the contract's code with the given input data and returns the return byte-slice
+	// and an error if one occurred.
+	Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error)
+}
+
+type InterpreterFactory func(evm *EVM, cfg Config) Interpreter
+
+var interpreter_registry = map[string]InterpreterFactory{}
+
+func RegisterInterpreterFactory(name string, factory InterpreterFactory) {
+	interpreter_registry[strings.ToLower(name)] = factory
+}
+
+func NewInterpreter(name string, evm *EVM, cfg Config) Interpreter {
+	factory, found := interpreter_registry[strings.ToLower(name)]
+	if !found {
+		panic(fmt.Sprintf("no factory for interpreter %s registered", name))
+	}
+	return factory(evm, cfg)
+}
+
+func init() {
+	factory := func(evm *EVM, cfg Config) Interpreter {
+		return NewEVMInterpreter(evm)
+	}
+	RegisterInterpreterFactory("", factory)
+	RegisterInterpreterFactory("geth", factory)
+}
+
+// --- Abstracted interpreter with step execution ---
+
+type Status int
+
+const (
+	Running Status = iota
+	Reverted
+	Stopped
+	Failed
+)
+
+// InterpreterState is a snapshot of the EVM state that can be used to test the effects of
+// running single operations.
+type InterpreterState struct {
+	Contract           *Contract
+	Status             Status
+	Input              []byte
+	ReadOnly           bool
+	Stack              *Stack
+	Memory             *Memory
+	Pc                 uint64
+	Error              error
+	LastCallReturnData []byte
+	ReturnData         []byte
+}
+
+func (in *EVMInterpreter) Step(state *InterpreterState) {
+	// run a single operation
+	res, err := in.run(state, 1)
+	if errors.Is(err, ErrExecutionReverted) {
+		state.Status = Reverted
+		state.ReturnData = res
+	} else if errors.Is(state.Error, errStopToken) {
+		state.Status = Stopped
+		state.ReturnData = res
+	} else if err != nil {
+		state.Status = Failed
+	} else {
+		state.Status = Running
+	}
+
+	// extract internal interpreter state
+	state.LastCallReturnData = in.returnData
+}

--- a/core/vm/tosca_integration_test.go
+++ b/core/vm/tosca_integration_test.go
@@ -1,0 +1,44 @@
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInterpreterFactory(t *testing.T) {
+	evm := &EVM{}
+	cfg := Config{}
+
+	interpreter := NewInterpreter("", evm, cfg)
+	if interpreter == nil {
+		t.Error("Expected interpreter to be created, but got nil")
+	}
+	interpreter = NewInterpreter("geth", evm, cfg)
+	if interpreter == nil {
+		t.Error("Expected interpreter to be created, but got nil")
+	}
+	asserted := assert.Panics(t, func() { NewInterpreter("invalid", evm, cfg) })
+	if !asserted {
+		t.Error("Expected panic with invalid interpreter name")
+	}
+}
+
+func TestInterpreterFactory_RegisterInterpreter(t *testing.T) {
+	evm := &EVM{}
+	cfg := Config{}
+	correctFactoryIsCalled := false
+
+	RegisterInterpreterFactory("newInterpreter", func(evm *EVM, cfg Config) Interpreter {
+		correctFactoryIsCalled = true
+		return NewEVMInterpreter(evm)
+	})
+
+	interpreter := NewInterpreter("newInterpreter", evm, cfg)
+	if interpreter == nil {
+		t.Error("Expected interpreter to be created, but got nil")
+	}
+	if !correctFactoryIsCalled {
+		t.Error("Wrong interpreter factory has been called")
+	}
+}


### PR DESCRIPTION
This PR modifies the EVM implementation to facilitate the following features:
- it adds a registry for interpreter implementations to facilitate the replacement of Geth`s implementation with third-party implementations, including Tosca's interpreter implementations
- it adds infrastructure for Geth's implementation to be tested using Tosca's Conformance Testing tool. This is required to establish Geth as the reference implementation for all Tosca interpreters.