### PR TITLE
Eliminate interpreter registry in Tosca integration

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -164,7 +164,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 		chainConfig: chainConfig,
 		chainRules:  chainConfig.Rules(blockCtx.BlockNumber, blockCtx.Random != nil, blockCtx.Time),
 	}
-	evm.interpreter = NewInterpreter(config.InterpreterImpl, evm, config)
+	evm.interpreter = getInterpreter(evm)
 	return evm
 }
 

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -36,7 +36,9 @@ type Config struct {
 	EnableWitnessCollection bool  // true if witness collection is enabled
 
 	StatePrecompiles map[common.Address]PrecompiledStateContract // Added by Fantom for custom precompiled contract
-	InterpreterImpl  string                                      // The interpreter implementation to use
+
+	Interpreter           InterpreterFactory // The interpreter implementation to use for non-tracing executions. If nil, EVMInterpreter will be used.
+	InterpreterForTracing InterpreterFactory // The interpreter implementation to use for tracing executions. If nil, Interpreter will be used.
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,

--- a/core/vm/tosca_integration.go
+++ b/core/vm/tosca_integration.go
@@ -2,9 +2,6 @@ package vm
 
 import (
 	"errors"
-	"fmt"
-	"strings"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
@@ -56,9 +53,7 @@ type CallContextInterceptor interface {
 	StaticCall(env *EVM, me ContractRef, addr common.Address, input []byte, gas uint64) ([]byte, uint64, error)
 }
 
-// -- Interpreter Implementation Registry --
-
-const ErrInterpreterNameCollision = constError("interpreter with same name already registered")
+// -- Interpreter --
 
 // Interpreter defines an interface for different interpreter implementations.
 type Interpreter interface {
@@ -69,56 +64,19 @@ type Interpreter interface {
 
 type InterpreterFactory func(evm *EVM) Interpreter
 
-var interpreterRegistryLock sync.Mutex
-var interpreterRegistry = map[string]InterpreterFactory{}
-
-func RegisterInterpreterFactory(name string, factory InterpreterFactory) error {
-	if factory == nil {
-		return fmt.Errorf("interpreter factory for %q is nil", name)
-	}
-	interpreterRegistryLock.Lock()
-	defer interpreterRegistryLock.Unlock()
-	name = strings.ToLower(name)
-	if _, found := interpreterRegistry[name]; found {
-		return ErrInterpreterNameCollision
-	}
-	interpreterRegistry[name] = factory
-	return nil
-}
-
-func NewInterpreter(name string, evm *EVM) Interpreter {
-	name = strings.ToLower(name)
-	interpreterRegistryLock.Lock()
-	factory, found := interpreterRegistry[name]
-	interpreterRegistryLock.Unlock()
-	if !found {
-		panic(fmt.Sprintf("no factory for interpreter %q registered", name))
-	}
-	return factory(evm)
-}
-
 func getInterpreter(evm *EVM) Interpreter {
 	// No Tosca interpreter is supporting tracing yet. Thus, if
 	// there is a tracer, we need to use Geth's EVMInterpreter.
-	if evm.Config.Tracer != nil {
-		return NewEVMInterpreter(evm)
+	config := &evm.Config
+	if config.Tracer != nil {
+		if config.InterpreterForTracing != nil {
+			return config.InterpreterForTracing(evm)
+		}
 	}
-	// Use the interpreter specified in the configuration.
-	return NewInterpreter(evm.Config.InterpreterImpl, evm)
-}
-
-func init() {
-	factory := func(evm *EVM) Interpreter {
-		return NewEVMInterpreter(evm)
+	if config.Interpreter != nil {
+		return config.Interpreter(evm)
 	}
-	RegisterInterpreterFactory("", factory)
-	RegisterInterpreterFactory("geth", factory)
-}
-
-type constError string
-
-func (e constError) Error() string {
-	return string(e)
+	return NewEVMInterpreter(evm)
 }
 
 // --- Abstracted interpreter with step execution ---

--- a/core/vm/tosca_integration_test.go
+++ b/core/vm/tosca_integration_test.go
@@ -1,80 +1,70 @@
 package vm
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestInterpreterFactory(t *testing.T) {
-	evm := &EVM{}
+func TestGetInterpreter_ProducesInterpretersBasedOnConfiguration(t *testing.T) {
+	var (
+		a         = &EVMInterpreter{}
+		b         = &EVMInterpreter{}
+		none      InterpreterFactory
+		useA      = func(*EVM) Interpreter { return a }
+		useB      = func(*EVM) Interpreter { return b }
+		A         = func(i Interpreter) bool { return i == a }
+		B         = func(i Interpreter) bool { return i == b }
+		Fresh     = func(i Interpreter) bool { return i != nil && i != a && i != b }
+		noTracing = false
+		Tracing   = true
+	)
 
-	interpreter := NewInterpreter("", evm)
-	if interpreter == nil {
-		t.Error("Expected interpreter to be created, but got nil")
-	}
-	interpreter = NewInterpreter("geth", evm)
-	if interpreter == nil {
-		t.Error("Expected interpreter to be created, but got nil")
-	}
-	asserted := assert.Panics(t, func() { NewInterpreter("invalid", evm) })
-	if !asserted {
-		t.Error("Expected panic with invalid interpreter name")
-	}
-}
+	// Defines a complete "truth" table for the GetInterpreter function.
+	tests := []struct {
+		tracing               bool
+		interpreter           InterpreterFactory
+		interpreterForTracing InterpreterFactory
+		want                  func(Interpreter) bool
+	}{
+		// tracing, interpreter, interpreterForTracing, want
+		{noTracing, none, none, Fresh},
+		{noTracing, none, useA, Fresh},
+		{noTracing, none, useB, Fresh},
 
-func TestInterpreterFactory_RegisterInterpreter(t *testing.T) {
-	evm := &EVM{}
-	correctFactoryIsCalled := false
+		{noTracing, useA, none, A},
+		{noTracing, useA, useA, A},
+		{noTracing, useA, useB, A},
 
-	RegisterInterpreterFactory("newInterpreter", func(evm *EVM) Interpreter {
-		correctFactoryIsCalled = true
-		return NewEVMInterpreter(evm)
-	})
+		{noTracing, useB, none, B},
+		{noTracing, useB, useA, B},
+		{noTracing, useB, useB, B},
 
-	interpreter := NewInterpreter("newInterpreter", evm)
-	if interpreter == nil {
-		t.Error("Expected interpreter to be created, but got nil")
-	}
-	if !correctFactoryIsCalled {
-		t.Error("Wrong interpreter factory has been called")
-	}
-}
+		{Tracing, none, none, Fresh},
+		{Tracing, none, useA, A},
+		{Tracing, none, useB, B},
 
-func TestInterpreterRegistry_NameCollisionsAreDetected(t *testing.T) {
-	const testInterpreter = "test-evm-001"
-	factory := func(evm *EVM) Interpreter { return nil }
-	err := RegisterInterpreterFactory(testInterpreter, factory)
-	if err != nil {
-		t.Error("Expected no error when registering new interpreter")
-	}
-	err = RegisterInterpreterFactory(testInterpreter, factory)
-	if !errors.Is(err, ErrInterpreterNameCollision) {
-		t.Errorf("Expected error %v, but got %v", ErrInterpreterNameCollision, err)
-	}
-}
+		{Tracing, useA, none, A},
+		{Tracing, useA, useA, A},
+		{Tracing, useA, useB, B},
 
-func TestGetInterpreter_ProducesGethInstanceWhenTracingIsEnabled(t *testing.T) {
-	const testInterpreter = "test-evm-002"
-	evm := &EVM{}
-	evm.Config.InterpreterImpl = testInterpreter
-
-	RegisterInterpreterFactory(testInterpreter, func(evm *EVM) Interpreter {
-		return nil
-	})
-
-	// Without tracer, the requested interpreter is provided.
-	interpreter := getInterpreter(evm)
-	if _, ok := interpreter.(*EVMInterpreter); ok {
-		t.Errorf("Expected interpreter from factory, but got Geth interpreter")
+		{Tracing, useB, none, B},
+		{Tracing, useB, useA, A},
+		{Tracing, useB, useB, B},
 	}
 
-	// With tracer, the Geth interpreter is provided.
-	evm.Config.Tracer = &tracing.Hooks{}
-	interpreter = getInterpreter(evm)
-	if _, ok := interpreter.(*EVMInterpreter); !ok {
-		t.Error("Expected Geth interpreter to be created, but got different")
+	for i, test := range tests {
+		config := Config{
+			Interpreter:           test.interpreter,
+			InterpreterForTracing: test.interpreterForTracing,
+		}
+		if test.tracing {
+			config.Tracer = &tracing.Hooks{}
+		}
+		evm := &EVM{Config: config}
+		got := getInterpreter(evm)
+		if !test.want(got) {
+			t.Errorf("unexpected interpreter, case %d -  isA: %t, isB: %t, isFresh: %t", i, A(got), B(got), Fresh(got))
+		}
 	}
 }

--- a/core/vm/tosca_integration_test.go
+++ b/core/vm/tosca_integration_test.go
@@ -1,24 +1,25 @@
 package vm
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestInterpreterFactory(t *testing.T) {
 	evm := &EVM{}
-	cfg := Config{}
 
-	interpreter := NewInterpreter("", evm, cfg)
+	interpreter := NewInterpreter("", evm)
 	if interpreter == nil {
 		t.Error("Expected interpreter to be created, but got nil")
 	}
-	interpreter = NewInterpreter("geth", evm, cfg)
+	interpreter = NewInterpreter("geth", evm)
 	if interpreter == nil {
 		t.Error("Expected interpreter to be created, but got nil")
 	}
-	asserted := assert.Panics(t, func() { NewInterpreter("invalid", evm, cfg) })
+	asserted := assert.Panics(t, func() { NewInterpreter("invalid", evm) })
 	if !asserted {
 		t.Error("Expected panic with invalid interpreter name")
 	}
@@ -26,19 +27,54 @@ func TestInterpreterFactory(t *testing.T) {
 
 func TestInterpreterFactory_RegisterInterpreter(t *testing.T) {
 	evm := &EVM{}
-	cfg := Config{}
 	correctFactoryIsCalled := false
 
-	RegisterInterpreterFactory("newInterpreter", func(evm *EVM, cfg Config) Interpreter {
+	RegisterInterpreterFactory("newInterpreter", func(evm *EVM) Interpreter {
 		correctFactoryIsCalled = true
 		return NewEVMInterpreter(evm)
 	})
 
-	interpreter := NewInterpreter("newInterpreter", evm, cfg)
+	interpreter := NewInterpreter("newInterpreter", evm)
 	if interpreter == nil {
 		t.Error("Expected interpreter to be created, but got nil")
 	}
 	if !correctFactoryIsCalled {
 		t.Error("Wrong interpreter factory has been called")
+	}
+}
+
+func TestInterpreterRegistry_NameCollisionsAreDetected(t *testing.T) {
+	const testInterpreter = "test-evm-001"
+	factory := func(evm *EVM) Interpreter { return nil }
+	err := RegisterInterpreterFactory(testInterpreter, factory)
+	if err != nil {
+		t.Error("Expected no error when registering new interpreter")
+	}
+	err = RegisterInterpreterFactory(testInterpreter, factory)
+	if !errors.Is(err, ErrInterpreterNameCollision) {
+		t.Errorf("Expected error %v, but got %v", ErrInterpreterNameCollision, err)
+	}
+}
+
+func TestGetInterpreter_ProducesGethInstanceWhenTracingIsEnabled(t *testing.T) {
+	const testInterpreter = "test-evm-002"
+	evm := &EVM{}
+	evm.Config.InterpreterImpl = testInterpreter
+
+	RegisterInterpreterFactory(testInterpreter, func(evm *EVM) Interpreter {
+		return nil
+	})
+
+	// Without tracer, the requested interpreter is provided.
+	interpreter := getInterpreter(evm)
+	if _, ok := interpreter.(*EVMInterpreter); ok {
+		t.Errorf("Expected interpreter from factory, but got Geth interpreter")
+	}
+
+	// With tracer, the Geth interpreter is provided.
+	evm.Config.Tracer = &tracing.Hooks{}
+	interpreter = getInterpreter(evm)
+	if _, ok := interpreter.(*EVMInterpreter); !ok {
+		t.Error("Expected Geth interpreter to be created, but got different")
 	}
 }


### PR DESCRIPTION
This PR simplifies the code modifications required to support alternative EVM interpreters in go-ethereum. The main updates are:
- the previous registry-based mechanism to select among multiple implementations by `name` got removed; instead of supporting the indirection via the registry, the interpreter is now directly included in the EVM configuration
- support for choosing different interpreter implementations for tracing and non-tracing cases was added
- redundant parameters in the interpreter factory got eliminated