### PR TITLE
Integrate EVM configuration options to support Fantom behavior

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -386,8 +386,6 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	// 3. the amount of gas required is available in the block
 	// 4. the purchased gas is enough to cover intrinsic usage
 	// 5. there is no overflow when calculating intrinsic gas
-	//
-	// Not in Fantom:
 	// 6. caller has enough balance to cover asset transfer for **topmost** call
 
 	// Check clauses 1-3, buy gas if everything is correct

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -237,16 +237,18 @@ func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).SetUint64(st.msg.GasLimit)
 	mgval.Mul(mgval, st.msg.GasPrice)
 	balanceCheck := new(big.Int).Set(mgval)
-	/*
+	if !st.evm.Config.IgnoreGasFeeCap {
 		if st.msg.GasFeeCap != nil {
 			balanceCheck.SetUint64(st.msg.GasLimit)
 			balanceCheck = balanceCheck.Mul(balanceCheck, st.msg.GasFeeCap)
 		}
-	*/
+	}
 
 	// Note: insufficient balance for **topmost** call isn't a consensus error in Opera, unlike Ethereum
 	// Such transaction will revert and consume sender's gas
-	//balanceCheck.Add(balanceCheck, st.msg.Value)
+	if !st.evm.Config.InsufficientBalanceIsNotAnError {
+		balanceCheck.Add(balanceCheck, st.msg.Value)
+	}
 
 	if st.evm.ChainConfig().IsCancun(st.evm.Context.BlockNumber, st.evm.Context.Time) {
 		if blobGas := st.blobGasUsed(); blobGas > 0 {
@@ -426,11 +428,11 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	if overflow {
 		return nil, fmt.Errorf("%w: address %v", ErrInsufficientFundsForTransfer, msg.From.Hex())
 	}
-	/*
+	if !st.evm.Config.InsufficientBalanceIsNotAnError {
 		if !value.IsZero() && !st.evm.Context.CanTransfer(st.state, msg.From, value) {
 			return nil, fmt.Errorf("%w: address %v", ErrInsufficientFundsForTransfer, msg.From.Hex())
 		}
-	*/
+	}
 
 	// Check whether the init code size has been exceeded.
 	if rules.IsShanghai && contractCreation && len(msg.Data) > params.MaxInitCodeSize {
@@ -454,11 +456,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), msg.Data, st.gasRemaining, value)
 	}
 
-	// Fantom modification: for all transactions that are not internal transactions, charge 10% of remaining gas.
-	// This should avoid gas-overspending in transactions, filling up blocks.
-	// TODO: make this configurable.
-	if msg.From != (common.Address{}) {
-		st.gasRemaining = st.gasRemaining - st.gasRemaining/10
+	if st.evm.Config.ChargeExcessGas {
+		// Fantom modification: for all transactions that are not internal transactions,
+		// charge 10% of remaining gas. This should avoid gas-overspending in transactions,
+		// filling up blocks.
+		if msg.From != (common.Address{}) {
+			st.gasRemaining = st.gasRemaining - st.gasRemaining/10
+		}
 	}
 
 	var gasRefund uint64
@@ -475,11 +479,11 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 	effectiveTipU256, _ := uint256.FromBig(effectiveTip)
 
-	if true || (st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0) {
+	if st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0 {
 		// Skip fee payment when NoBaseFee is set and the fee fields
 		// are 0. This avoids a negative effectiveTip being applied to
 		// the coinbase when simulating calls.
-	} else {
+	} else if !st.evm.Config.SkipTipPaymentToCoinbase {
 		fee := new(uint256.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTipU256)
 		st.state.AddBalance(st.evm.Context.Coinbase, fee, tracing.BalanceIncreaseRewardTransactionFee)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -237,10 +237,12 @@ func (st *StateTransition) buyGas() error {
 	mgval := new(big.Int).SetUint64(st.msg.GasLimit)
 	mgval.Mul(mgval, st.msg.GasPrice)
 	balanceCheck := new(big.Int).Set(mgval)
-	if st.msg.GasFeeCap != nil {
-		balanceCheck.SetUint64(st.msg.GasLimit)
-		balanceCheck = balanceCheck.Mul(balanceCheck, st.msg.GasFeeCap)
-	}
+	/*
+		if st.msg.GasFeeCap != nil {
+			balanceCheck.SetUint64(st.msg.GasLimit)
+			balanceCheck = balanceCheck.Mul(balanceCheck, st.msg.GasFeeCap)
+		}
+	*/
 
 	// Note: insufficient balance for **topmost** call isn't a consensus error in Opera, unlike Ethereum
 	// Such transaction will revert and consume sender's gas
@@ -473,7 +475,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	}
 	effectiveTipU256, _ := uint256.FromBig(effectiveTip)
 
-	if st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0 {
+	if true || (st.evm.Config.NoBaseFee && msg.GasFeeCap.Sign() == 0 && msg.GasTipCap.Sign() == 0) {
 		// Skip fee payment when NoBaseFee is set and the fee fields
 		// are 0. This avoids a negative effectiveTip being applied to
 		// the coinbase when simulating calls.

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -445,6 +445,13 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 		ret, st.gasRemaining, vmerr = st.evm.Call(sender, st.to(), msg.Data, st.gasRemaining, value)
 	}
 
+	// Fantom modification: for all transactions that are not internal transactions, charge 10% of remaining gas.
+	// This should avoid gas-overspending in transactions, filling up blocks.
+	// TODO: make this configurable.
+	if msg.From != (common.Address{}) {
+		st.gasRemaining = st.gasRemaining - st.gasRemaining/10
+	}
+
 	var gasRefund uint64
 	if !rules.IsLondon {
 		// Before EIP-3529: refunds were capped to gasUsed / 2

--- a/core/state_transition_test.go
+++ b/core/state_transition_test.go
@@ -1,0 +1,277 @@
+package core
+
+import (
+	"errors"
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/stateless"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/holiman/uint256"
+)
+
+func TestStateTransition_EnablingExcessGasChargingEnablesExcessGasCharging(t *testing.T) {
+	msg := &Message{
+		From:     common.Address{12},
+		GasLimit: 100_000,
+	}
+
+	config := vm.Config{
+		ChargeExcessGas: false,
+	}
+
+	resultWithoutCharge, err := runTestTransaction(msg, config)
+	if err != nil {
+		t.Fatalf("Error running transaction: %v", err)
+	}
+
+	config.ChargeExcessGas = true
+	resultWithCharge, err := runTestTransaction(msg, config)
+	if err != nil {
+		t.Fatalf("Error running transaction: %v", err)
+	}
+
+	// When enabled, 10% of the excess gas is charged
+	want := (msg.GasLimit - resultWithoutCharge.UsedGas) / 10
+	diff := resultWithCharge.UsedGas - resultWithoutCharge.UsedGas
+	if diff != want {
+		t.Fatalf("Expected difference in gas usage to be %d, got %d", want, diff)
+	}
+}
+
+func TestStateTransition_ExcessiveGasChargesAreIgnoredForTheZeroSender(t *testing.T) {
+	msg := &Message{
+		From:     common.Address{0},
+		GasLimit: 100_000,
+	}
+
+	config := vm.Config{
+		ChargeExcessGas: false,
+	}
+
+	resultWithoutCharge, err := runTestTransaction(msg, config)
+	if err != nil {
+		t.Fatalf("Error running transaction: %v", err)
+	}
+
+	config.ChargeExcessGas = true
+	resultWithCharge, err := runTestTransaction(msg, config)
+	if err != nil {
+		t.Fatalf("Error running transaction: %v", err)
+	}
+
+	if resultWithCharge.UsedGas != resultWithoutCharge.UsedGas {
+		t.Fatalf("Expected gas usage to be the same, got %d and %d", resultWithoutCharge.UsedGas, resultWithCharge.UsedGas)
+	}
+}
+
+func TestStateTransition_InsufficientBalanceCheckCanBeDisabled(t *testing.T) {
+	msg := &Message{
+		Value:    big.NewInt(2_000_000), // - all accounts have 1_000_000 in the dummy DB
+		GasLimit: 100_000,
+	}
+
+	config := vm.Config{
+		InsufficientBalanceIsNotAnError: false,
+	}
+
+	_, err := runTestTransaction(msg, config)
+	if err == nil {
+		t.Errorf("Expected error running transaction with not enough balance")
+	}
+
+	// When disabled, the transaction is still processed but reverted.
+	config.InsufficientBalanceIsNotAnError = true
+	result, err := runTestTransaction(msg, config)
+	if err != nil {
+		t.Errorf("Error running transaction: %v", err)
+	}
+	if errors.Is(result.Err, vm.ErrExecutionReverted) {
+		t.Errorf("Expected error to be reverted, got %v", result.Err)
+	}
+}
+
+func TestStateTransition_GasFeeCapCanBeIgnored(t *testing.T) {
+	msg := &Message{
+		GasLimit:  100_000,
+		GasFeeCap: big.NewInt(8),  // 1M in each account should be enough
+		GasPrice:  big.NewInt(12), // 1M is not enough for this gas price
+	}
+
+	config := vm.Config{
+		IgnoreGasFeeCap: false,
+	}
+
+	// By default, the gas fee cap is enforced and the transaction should pass.
+	_, err := runTestTransaction(msg, config)
+	if err != nil {
+		t.Errorf("expected transaction to pass when enforcing gas fee cap")
+	}
+
+	// When ignoring the gas fee cap, the transaction should be too expensive.
+	config.IgnoreGasFeeCap = true
+	_, err = runTestTransaction(msg, config)
+	if err == nil {
+		t.Errorf("expected transaction to fail when ignoring gas fee cap")
+	}
+}
+
+func TestStateTransition_GasTipPaymentToCoinbaseCanBeSkipped(t *testing.T) {
+	msg := &Message{
+		GasLimit: 100_000,
+		GasPrice: big.NewInt(5),
+	}
+
+	config := vm.Config{
+		SkipTipPaymentToCoinbase: false,
+	}
+
+	// By default, gas fees are send to the coinbase.
+	result, balance, err := runTestTransactionAndGetBalance(msg, config, testCoinbase)
+	if err != nil {
+		t.Errorf("transaction failed: %v", err)
+	}
+	if got, want := balance.Uint64(), uint64(1_000_000+result.UsedGas*5); got != want {
+		t.Errorf("expected coinbase balance to be %d, got %d", want, got)
+	}
+
+	// When disabled, transfers are skipped.
+	config.SkipTipPaymentToCoinbase = true
+	_, balance, err = runTestTransactionAndGetBalance(msg, config, testCoinbase)
+	if err != nil {
+		t.Errorf("transaction failed: %v", err)
+	}
+	if got, want := balance.Uint64(), uint64(1_000_000); got != want {
+		t.Errorf("expected coinbase balance to be %d, got %d", want, got)
+	}
+}
+
+///////////////////////////
+// Helper functions
+
+var testCoinbase = common.Address{15}
+
+func runTestTransaction(msg *Message, config vm.Config) (*ExecutionResult, error) {
+	result, _, err := runTestTransactionAndGetBalance(msg, config, common.Address{})
+	return result, err
+}
+
+func runTestTransactionAndGetBalance(
+	msg *Message,
+	config vm.Config,
+	address common.Address,
+) (*ExecutionResult, *uint256.Int, error) {
+	evm := vm.NewEVM(
+		vm.BlockContext{
+			Transfer:    func(vm.StateDB, common.Address, common.Address, *uint256.Int) {},
+			CanTransfer: func(vm.StateDB, common.Address, *uint256.Int) bool { return true },
+			Coinbase:    testCoinbase,
+		},
+		vm.TxContext{},
+		&dummyStateDB{
+			accountToTrack: address,
+		},
+		&params.ChainConfig{},
+		config,
+	)
+
+	if msg.To == nil {
+		msg.To = &common.Address{14}
+	}
+	if msg.GasPrice == nil {
+		msg.GasPrice = big.NewInt(0)
+	}
+	if msg.GasFeeCap == nil {
+		msg.GasFeeCap = big.NewInt(0)
+	}
+	if msg.GasTipCap == nil {
+		msg.GasTipCap = big.NewInt(0)
+	}
+	if msg.Value == nil {
+		msg.Value = big.NewInt(0)
+	}
+
+	pool := new(GasPool)
+	pool.AddGas(100_000)
+
+	result, err := ApplyMessage(evm, msg, pool)
+	return result, evm.StateDB.GetBalance(address), err
+}
+
+///////////////////////////
+// dummyStateDB
+
+type dummyStateDB struct {
+	vm.StateDB
+
+	accountToTrack common.Address
+	accountBalance *uint256.Int
+}
+
+func (*dummyStateDB) Exist(common.Address) bool {
+	return true
+}
+
+func (db *dummyStateDB) GetBalance(addr common.Address) *uint256.Int {
+	if addr == db.accountToTrack && db.accountBalance != nil {
+		return db.accountBalance
+	}
+	return uint256.NewInt(1_000_000)
+}
+
+func (db *dummyStateDB) AddBalance(addr common.Address, value *uint256.Int, _ tracing.BalanceChangeReason) {
+	if addr == db.accountToTrack {
+		cur := db.GetBalance(addr)
+		db.accountBalance = cur.Add(cur, value)
+	}
+}
+
+func (*dummyStateDB) SubBalance(common.Address, *uint256.Int, tracing.BalanceChangeReason) {
+	// ignored
+}
+
+func (*dummyStateDB) GetNonce(common.Address) uint64 {
+	return 0
+}
+
+func (*dummyStateDB) SetNonce(common.Address, uint64) {
+	// ignored
+}
+
+func (*dummyStateDB) GetCodeHash(common.Address) common.Hash {
+	return common.Hash{}
+}
+
+func (*dummyStateDB) GetCode(common.Address) []byte {
+	return nil
+}
+
+func (*dummyStateDB) AddRefund(uint64) {
+	// ignored
+}
+func (*dummyStateDB) SubRefund(uint64) {
+	// ignored
+}
+func (*dummyStateDB) GetRefund() uint64 {
+	return 0
+}
+
+func (*dummyStateDB) Prepare(params.Rules, common.Address, common.Address, *common.Address, []common.Address, types.AccessList) {
+	// ignored
+}
+
+func (*dummyStateDB) Snapshot() int {
+	return 0
+}
+
+func (*dummyStateDB) RevertToSnapshot(int) {
+	// ignored
+}
+
+func (*dummyStateDB) Witness() *stateless.Witness {
+	return nil
+}

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -42,7 +42,7 @@ type Config struct {
 
 	// -- Fantom / Sonic specific configuration options --
 	// By setting the following flags to their default values, the EVM will behave as the vanilla Ethereum EVM.
-	// To get the Fantom-main-net behavior, of of the following flags need to be enabled. Future networks may
+	// To get the Fantom-main-net behavior, all of the following flags need to be enabled. Future networks may
 	// have different configurations.
 	ChargeExcessGas                 bool // if enabled, 10% of excessive gas is charged for the execution
 	IgnoreGasFeeCap                 bool // if enabled, gas fee cap is ignored

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -39,6 +39,15 @@ type Config struct {
 
 	Interpreter           InterpreterFactory // The interpreter implementation to use for non-tracing executions. If nil, EVMInterpreter will be used.
 	InterpreterForTracing InterpreterFactory // The interpreter implementation to use for tracing executions. If nil, Interpreter will be used.
+
+	// -- Fantom / Sonic specific configuration options --
+	// By setting the following flags to their default values, the EVM will behave as the vanilla Ethereum EVM.
+	// To get the Fantom-main-net behavior, of of the following flags need to be enabled. Future networks may
+	// have different configurations.
+	ChargeExcessGas                 bool // if enabled, 10% of excessive gas is charged for the execution
+	IgnoreGasFeeCap                 bool // if enabled, gas fee cap is ignored
+	InsufficientBalanceIsNotAnError bool // if enabled, insufficient balance is treated as a revert, not an execution error on the top level
+	SkipTipPaymentToCoinbase        bool // if enabled, tip payment is not made to the coinbase address
 }
 
 // ScopeContext contains the things that are per-call, such as stack and memory,


### PR DESCRIPTION
This PR introduces four additional configuration options that facilitate the configuration of the geth EVM to match the configuration required for processing transactions on the Fantom network.

These flags include:
- `ChargeExcessGas` to enable charging 10% of the remaining gas as a over-provisioning fee
- `IgnoreGasFeeCap` to ignore the user defined gas-fee cap
- `InsufficientBalanceIsNotAnError` to let transactions with insufficient balance revert instead of fail with an error
- `SkipTipPaymentToCoinbase` to disable the transfer of transaction tips to the coinbase

Based on historic evaluations, these are the 4 differences that could be identified between the Opera/Sonic EVM and the go-ethereum EVM.