### PR TITLE
makes ethereum tests configurable to inject db implementations

### DIFF
--- a/tests/db_factory.go
+++ b/tests/db_factory.go
@@ -2,16 +2,10 @@ package tests
 
 import (
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
-	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/triedb"
-	"github.com/ethereum/go-ethereum/triedb/hashdb"
-	"github.com/ethereum/go-ethereum/triedb/pathdb"
 	"github.com/holiman/uint256"
 )
 
@@ -44,56 +38,6 @@ type TestStateDB interface {
 // TestContextFactory is an interface for creating test configurations.
 type TestContextFactory interface {
 
-	// NewTestStateDB creates a new TestStateDB and provides a callback to set up the pre-state.
-	// The implementation should create a new fresh database, apply data provided in the callback,
-	// flush results and clean all temporal states.
-	// In practices, a sealed state such as state root hash should be available after the call,
-	// and the database should be ready for the next state transition.
-	NewTestStateDB(makePreState func(db TestStateDB)) StateTestState
-}
-
-// gethFactory is a factory for creating geth database.
-type gethFactory struct {
-	db          ethdb.Database
-	snapshotter bool
-	scheme      string
-}
-
-// NewGethFactory creates a new gethFactory.
-func NewGethFactory(db ethdb.Database, snapshotter bool, scheme string) TestContextFactory {
-	return gethFactory{db, snapshotter, scheme}
-}
-
-// NewTestStateDB creates a new StateTestState using geth database.
-func (f gethFactory) NewTestStateDB(makePreState func(db TestStateDB)) StateTestState {
-	tconf := &triedb.Config{Preimages: true}
-	if f.scheme == rawdb.HashScheme {
-		tconf.HashDB = hashdb.Defaults
-	} else {
-		tconf.PathDB = pathdb.Defaults
-	}
-
-	triedb := triedb.NewDatabase(f.db, tconf)
-	sdb := state.NewDatabaseWithNodeDB(f.db, triedb)
-	statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
-
-	makePreState(statedb)
-
-	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(0, false)
-
-	// If snapshot is requested, initialize the snapshotter and use it in state.
-	var snaps *snapshot.Tree
-	if f.snapshotter {
-		snapconfig := snapshot.Config{
-			CacheSize:  1,
-			Recovery:   false,
-			NoBuild:    false,
-			AsyncBuild: false,
-		}
-		snaps, _ = snapshot.New(snapconfig, f.db, triedb, root)
-	}
-	statedb, _ = state.New(root, sdb, snaps)
-
-	return StateTestState{statedb, triedb, snaps}
+	// NewTestStateDB creates a new StateTestState instance.
+	NewTestStateDB(accounts types.GenesisAlloc) StateTestState
 }

--- a/tests/db_factory.go
+++ b/tests/db_factory.go
@@ -1,0 +1,99 @@
+package tests
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/core/tracing"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/ethereum/go-ethereum/triedb/hashdb"
+	"github.com/ethereum/go-ethereum/triedb/pathdb"
+	"github.com/holiman/uint256"
+)
+
+// TestStateDB allows for switching database implementation for running tests.
+// It is an extension of vm.StateDB with additional methods that were originally
+// available only at an implementation level of the geth database.
+// Not all methods have to be available in all implementations, and clients
+// should pair expected method outputs with the actual implementation.
+type TestStateDB interface {
+	vm.StateDB
+
+	// Database returns the underlying database.
+	Database() state.Database
+
+	// Logs returns the logs of the current transaction.
+	Logs() []*types.Log
+
+	SetLogger(l *tracing.Hooks)
+
+	// SetBalance sets the balance of the given account.
+	SetBalance(addr common.Address, amount *uint256.Int, reason tracing.BalanceChangeReason)
+
+	// IntermediateRoot returns current state root hash.
+	IntermediateRoot(deleteEmptyObjects bool) common.Hash
+
+	// Commit commits the state to the underlying trie database and returns state root hash.
+	Commit(block uint64, deleteEmptyObjects bool) (common.Hash, error)
+}
+
+// TestContextFactory is an interface for creating test configurations.
+type TestContextFactory interface {
+
+	// NewTestStateDB creates a new TestStateDB and provides a callback to set up the pre-state.
+	// The implementation should create a new fresh database, apply data provided in the callback,
+	// flush results and clean all temporal states.
+	// In practices, a sealed state such as state root hash should be available after the call,
+	// and the database should be ready for the next state transition.
+	NewTestStateDB(makePreState func(db TestStateDB)) StateTestState
+}
+
+// gethFactory is a factory for creating geth database.
+type gethFactory struct {
+	db          ethdb.Database
+	snapshotter bool
+	scheme      string
+}
+
+// NewGethFactory creates a new gethFactory.
+func NewGethFactory(db ethdb.Database, snapshotter bool, scheme string) TestContextFactory {
+	return gethFactory{db, snapshotter, scheme}
+}
+
+// NewTestStateDB creates a new StateTestState using geth database.
+func (f gethFactory) NewTestStateDB(makePreState func(db TestStateDB)) StateTestState {
+	tconf := &triedb.Config{Preimages: true}
+	if f.scheme == rawdb.HashScheme {
+		tconf.HashDB = hashdb.Defaults
+	} else {
+		tconf.PathDB = pathdb.Defaults
+	}
+
+	triedb := triedb.NewDatabase(f.db, tconf)
+	sdb := state.NewDatabaseWithNodeDB(f.db, triedb)
+	statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
+
+	makePreState(statedb)
+
+	// Commit and re-open to start with a clean state.
+	root, _ := statedb.Commit(0, false)
+
+	// If snapshot is requested, initialize the snapshotter and use it in state.
+	var snaps *snapshot.Tree
+	if f.snapshotter {
+		snapconfig := snapshot.Config{
+			CacheSize:  1,
+			Recovery:   false,
+			NoBuild:    false,
+			AsyncBuild: false,
+		}
+		snaps, _ = snapshot.New(snapconfig, f.db, triedb, root)
+	}
+	statedb, _ = state.New(root, sdb, snaps)
+
+	return StateTestState{statedb, triedb, snaps}
+}

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -22,9 +22,12 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/ethereum/go-ethereum/triedb/hashdb"
+	"github.com/ethereum/go-ethereum/triedb/pathdb"
 	"math/big"
 	"strconv"
 	"strings"
@@ -464,24 +467,64 @@ type StateTestState struct {
 
 // MakePreState creates a state containing the given allocation.
 func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bool, scheme string) StateTestState {
-	factory := NewGethFactory(db, snapshotter, scheme)
+	factory := newGethFactory(db, snapshotter, scheme)
 	return MakePreStateWith(accounts, factory)
 }
 
 // MakePreStateWith creates a state containing the given allocation.
 // It allows for injecting a custom TestContextFactory configuring database.
 func MakePreStateWith(accounts types.GenesisAlloc, fact TestContextFactory) StateTestState {
-	st := fact.NewTestStateDB(func(statedb TestStateDB) {
-		for addr, a := range accounts {
-			statedb.SetCode(addr, a.Code)
-			statedb.SetNonce(addr, a.Nonce)
-			statedb.SetBalance(addr, uint256.MustFromBig(a.Balance), tracing.BalanceChangeUnspecified)
-			for k, v := range a.Storage {
-				statedb.SetState(addr, k, v)
-			}
-		}
-	})
+	st := fact.NewTestStateDB(accounts)
 	return st
+}
+
+// gethFactory is a factory for creating geth database.
+type gethFactory struct {
+	db          ethdb.Database
+	snapshotter bool
+	scheme      string
+}
+
+// newGethFactory creates a new gethFactory.
+func newGethFactory(db ethdb.Database, snapshotter bool, scheme string) TestContextFactory {
+	return gethFactory{db, snapshotter, scheme}
+}
+
+// NewTestStateDB creates a new StateTestState using geth database.
+func (f gethFactory) NewTestStateDB(accounts types.GenesisAlloc) StateTestState {
+	tconf := &triedb.Config{Preimages: true}
+	if f.scheme == rawdb.HashScheme {
+		tconf.HashDB = hashdb.Defaults
+	} else {
+		tconf.PathDB = pathdb.Defaults
+	}
+	triedb := triedb.NewDatabase(f.db, tconf)
+	sdb := state.NewDatabaseWithNodeDB(f.db, triedb)
+	statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
+	for addr, a := range accounts {
+		statedb.SetCode(addr, a.Code)
+		statedb.SetNonce(addr, a.Nonce)
+		statedb.SetBalance(addr, uint256.MustFromBig(a.Balance), tracing.BalanceChangeUnspecified)
+		for k, v := range a.Storage {
+			statedb.SetState(addr, k, v)
+		}
+	}
+	// Commit and re-open to start with a clean state.
+	root, _ := statedb.Commit(0, false)
+
+	// If snapshot is requested, initialize the snapshotter and use it in state.
+	var snaps *snapshot.Tree
+	if f.snapshotter {
+		snapconfig := snapshot.Config{
+			CacheSize:  1,
+			Recovery:   false,
+			NoBuild:    false,
+			AsyncBuild: false,
+		}
+		snaps, _ = snapshot.New(snapconfig, f.db, triedb, root)
+	}
+	statedb, _ = state.New(root, sdb, snaps)
+	return StateTestState{statedb, triedb, snaps}
 }
 
 // Close should be called when the state is no longer needed, ie. after running the test.

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -21,13 +21,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/state/snapshot"
-	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/triedb"
-	"github.com/ethereum/go-ethereum/triedb/hashdb"
-	"github.com/ethereum/go-ethereum/triedb/pathdb"
 	"math/big"
 	"strconv"
 	"strings"
@@ -37,12 +30,19 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/ethereum/go-ethereum/triedb/hashdb"
+	"github.com/ethereum/go-ethereum/triedb/pathdb"
 	"github.com/holiman/uint256"
 	"golang.org/x/crypto/sha3"
 )
@@ -196,7 +196,7 @@ func (t *StateTest) checkError(subtest StateSubtest, err error) error {
 
 // Run executes a specific subtest and verifies the post-state and logs
 func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config, snapshotter bool, scheme string, postCheck func(err error, st *StateTestState)) (result error) {
-	factory := NewGethFactory(rawdb.NewMemoryDatabase(), snapshotter, scheme)
+	factory := newGethFactory(rawdb.NewMemoryDatabase(), snapshotter, scheme)
 	return t.RunWith(subtest, vmconfig, factory, postCheck)
 }
 
@@ -235,7 +235,7 @@ func (t *StateTest) RunWith(subtest StateSubtest, vmconfig vm.Config, factory Te
 // RunNoVerify runs a specific subtest and returns the statedb and post-state root.
 // Remember to call state.Close after verifying the test result!
 func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapshotter bool, scheme string) (st StateTestState, root common.Hash, err error) {
-	factory := NewGethFactory(rawdb.NewMemoryDatabase(), snapshotter, scheme)
+	factory := newGethFactory(rawdb.NewMemoryDatabase(), snapshotter, scheme)
 	return t.RunNoVerifyWith(subtest, vmconfig, factory)
 }
 

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -21,6 +21,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state/snapshot"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/triedb"
 	"math/big"
 	"strconv"
 	"strings"
@@ -30,19 +34,12 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus/misc/eip4844"
 	"github.com/ethereum/go-ethereum/core"
-	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/state"
-	"github.com/ethereum/go-ethereum/core/state/snapshot"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
-	"github.com/ethereum/go-ethereum/triedb"
-	"github.com/ethereum/go-ethereum/triedb/hashdb"
-	"github.com/ethereum/go-ethereum/triedb/pathdb"
 	"github.com/holiman/uint256"
 	"golang.org/x/crypto/sha3"
 )
@@ -196,7 +193,14 @@ func (t *StateTest) checkError(subtest StateSubtest, err error) error {
 
 // Run executes a specific subtest and verifies the post-state and logs
 func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config, snapshotter bool, scheme string, postCheck func(err error, st *StateTestState)) (result error) {
-	st, root, err := t.RunNoVerify(subtest, vmconfig, snapshotter, scheme)
+	factory := NewGethFactory(rawdb.NewMemoryDatabase(), snapshotter, scheme)
+	return t.RunWith(subtest, vmconfig, factory, postCheck)
+}
+
+// RunWith executes a specific subtest and verifies the post-state and logs.
+// It allows for injecting a custom TestContextFactory configuring state processor components.
+func (t *StateTest) RunWith(subtest StateSubtest, vmconfig vm.Config, factory TestContextFactory, postCheck func(err error, st *StateTestState)) (result error) {
+	st, root, err := t.RunNoVerifyWith(subtest, vmconfig, factory)
 	// Invoke the callback at the end of function for further analysis.
 	defer func() {
 		postCheck(result, &st)
@@ -222,13 +226,20 @@ func (t *StateTest) Run(subtest StateSubtest, vmconfig vm.Config, snapshotter bo
 	if logs := rlpHash(st.StateDB.Logs()); logs != common.Hash(post.Logs) {
 		return fmt.Errorf("post state logs hash mismatch: got %x, want %x", logs, post.Logs)
 	}
-	st.StateDB, _ = state.New(root, st.StateDB.Database(), st.Snapshots)
 	return nil
 }
 
 // RunNoVerify runs a specific subtest and returns the statedb and post-state root.
 // Remember to call state.Close after verifying the test result!
 func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapshotter bool, scheme string) (st StateTestState, root common.Hash, err error) {
+	factory := NewGethFactory(rawdb.NewMemoryDatabase(), snapshotter, scheme)
+	return t.RunNoVerifyWith(subtest, vmconfig, factory)
+}
+
+// RunNoVerifyWith runs a specific subtest and returns the statedb and post-state root.
+// Remember to call state.Close after verifying the test result!
+// It allows for injecting a custom TestContextFactory configuring state processor components.
+func (t *StateTest) RunNoVerifyWith(subtest StateSubtest, vmconfig vm.Config, factory TestContextFactory) (st StateTestState, root common.Hash, err error) {
 	config, eips, err := GetChainConfig(subtest.Fork)
 	if err != nil {
 		return st, common.Hash{}, UnsupportedForkError{subtest.Fork}
@@ -236,7 +247,7 @@ func (t *StateTest) RunNoVerify(subtest StateSubtest, vmconfig vm.Config, snapsh
 	vmconfig.ExtraEips = eips
 
 	block := t.genesis(config).ToBlock()
-	st = MakePreState(rawdb.NewMemoryDatabase(), t.json.Pre, snapshotter, scheme)
+	st = MakePreStateWith(t.json.Pre, factory)
 
 	var baseFee *big.Int
 	if config.IsLondon(new(big.Int)) {
@@ -446,46 +457,31 @@ func vmTestBlockHash(n uint64) common.Hash {
 
 // StateTestState groups all the state database objects together for use in tests.
 type StateTestState struct {
-	StateDB   *state.StateDB
+	StateDB   TestStateDB
 	TrieDB    *triedb.Database
 	Snapshots *snapshot.Tree
 }
 
 // MakePreState creates a state containing the given allocation.
 func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bool, scheme string) StateTestState {
-	tconf := &triedb.Config{Preimages: true}
-	if scheme == rawdb.HashScheme {
-		tconf.HashDB = hashdb.Defaults
-	} else {
-		tconf.PathDB = pathdb.Defaults
-	}
-	triedb := triedb.NewDatabase(db, tconf)
-	sdb := state.NewDatabaseWithNodeDB(db, triedb)
-	statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
-	for addr, a := range accounts {
-		statedb.SetCode(addr, a.Code)
-		statedb.SetNonce(addr, a.Nonce)
-		statedb.SetBalance(addr, uint256.MustFromBig(a.Balance), tracing.BalanceChangeUnspecified)
-		for k, v := range a.Storage {
-			statedb.SetState(addr, k, v)
-		}
-	}
-	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(0, false)
+	factory := NewGethFactory(db, snapshotter, scheme)
+	return MakePreStateWith(accounts, factory)
+}
 
-	// If snapshot is requested, initialize the snapshotter and use it in state.
-	var snaps *snapshot.Tree
-	if snapshotter {
-		snapconfig := snapshot.Config{
-			CacheSize:  1,
-			Recovery:   false,
-			NoBuild:    false,
-			AsyncBuild: false,
+// MakePreStateWith creates a state containing the given allocation.
+// It allows for injecting a custom TestContextFactory configuring database.
+func MakePreStateWith(accounts types.GenesisAlloc, fact TestContextFactory) StateTestState {
+	st := fact.NewTestStateDB(func(statedb TestStateDB) {
+		for addr, a := range accounts {
+			statedb.SetCode(addr, a.Code)
+			statedb.SetNonce(addr, a.Nonce)
+			statedb.SetBalance(addr, uint256.MustFromBig(a.Balance), tracing.BalanceChangeUnspecified)
+			for k, v := range a.Storage {
+				statedb.SetState(addr, k, v)
+			}
 		}
-		snaps, _ = snapshot.New(snapconfig, db, triedb, root)
-	}
-	statedb, _ = state.New(root, sdb, snaps)
-	return StateTestState{statedb, triedb, snaps}
+	})
+	return st
 }
 
 // Close should be called when the state is no longer needed, ie. after running the test.


### PR DESCRIPTION
This PR updates ethereum state tests the way they can accept various database implementations via a factory.

A default factory with original Geth DB is provided. 

All tests pass with this change  