### PR TITLE
Geth tosca integration, no code is stop

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -201,6 +201,8 @@ func (in *EVMInterpreter) run(state *InterpreterState, maxSteps uint64) (ret []b
 
 	// Don't bother with the execution if there's no code.
 	if len(contract.Code) == 0 {
+		// no code is treated as STOP
+		state.Error = errStopToken
 		return nil, nil
 	}
 

--- a/core/vm/tosca_integration.go
+++ b/core/vm/tosca_integration.go
@@ -116,9 +116,6 @@ func (in *EVMInterpreter) Step(state *InterpreterState) {
 		state.ReturnData = res
 	} else if err != nil {
 		state.Status = Failed
-	} else if len(state.Contract.Code) == 0 {
-		// No contract code is treated as a stop, to avoid infinite loops
-		state.Status = Stopped
 	} else {
 		state.Status = Running
 	}

--- a/core/vm/tosca_integration.go
+++ b/core/vm/tosca_integration.go
@@ -116,6 +116,9 @@ func (in *EVMInterpreter) Step(state *InterpreterState) {
 		state.ReturnData = res
 	} else if err != nil {
 		state.Status = Failed
+	} else if len(state.Contract.Code) == 0 {
+		// No contract code is treated as a stop, to avoid infinite loops
+		state.Status = Stopped
 	} else {
 		state.Status = Running
 	}


### PR DESCRIPTION
A call with no code returns immediately, keeping the status running. This would create an endless loop and therefore has to be changed to stopped for the stepN function.
This solution adds a special case to the status conversion which is not ideal but the most minimal way of solving the problem.